### PR TITLE
change the argument type of removeConverter

### DIFF
--- a/src/DavidBadura/Fixtures/Executor/Executor.php
+++ b/src/DavidBadura/Fixtures/Executor/Executor.php
@@ -56,9 +56,9 @@ class Executor implements ExecutorInterface
 
     /**
      *
-     * @param ConverterInterface $converter
+     * @param string $converter
      */
-    public function removeConverter(ConverterInterface $converter)
+    public function removeConverter($converter)
     {
         $this->converterRepository->removeConverter($converter);
     }


### PR DESCRIPTION
This fixes an issue, which prevented the removal of Converters because the executer->removeConverter passed down an ConverterInstance instead of the Name as string the Repository expects
