### PR TITLE
Allow fixture data for fields with generated values

### DIFF
--- a/src/DavidBadura/Fixtures/Persister/DoctrinePersister.php
+++ b/src/DavidBadura/Fixtures/Persister/DoctrinePersister.php
@@ -34,6 +34,17 @@ class DoctrinePersister implements PersisterInterface
     public function persist(FixtureData $data)
     {
         $object = $data->getObject();
+
+        $metadata = $this->om->getClassMetadata(get_class($object));
+        $identifier = $metadata->getIdentifier();
+
+        if ($metadata->usesIdGenerator()
+            && count(array_intersect($identifier, array_keys($data->getData()))) > 0
+        ) {
+            $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
+            $metadata->setIdGenerator(new \Doctrine\ORM\Id\AssignedGenerator());
+        }
+
         $this->om->persist($object);
     }
 


### PR DESCRIPTION
If you have an Entity, let's say:

```php
class Entity {
    /**
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="UUID")
     */
    private $id;

    public function setId($id) {
        $this->id = $id;
    }
}
```

... you can't set an ID with fixtures because Doctrine overrides all your values with the values from the generator. I found a [solution on stackoverflow.com](http://stackoverflow.com/q/5301285/315257) and implemented it in the DoctrinePersister.

How it works: If the entity-to-save has an ID field and the entity uses @GeneratedValue, the generator will be disabled if you provide data for this field in your fixture. Otherwise the generator stays enabled (enabled generators is current behavior).

Drawbacks? Yes: an edge-case would be if you have multiple @IDs in your entity but just data for some of them in your fixture. In this case, the generators for all IDs would get disabled but just data for some IDs is provided which would result in an insert with with NULL-values on ID-columns. But i don't know when this case would be fulfilled. This is just because i didn't found a way to disable the generators on a per-field basis instead of an per-entity basis.

I would love to here opinions about this PR.

P.S: Another solution may be to implement an additional DoctrinePersister which inherits from the current DoctrinePersister which implement this logic. This way the user could decide if he want's the magic.