### PR TITLE
Pass objects in fixtures data

### DIFF
--- a/src/DavidBadura/Fixtures/Executor/Executor.php
+++ b/src/DavidBadura/Fixtures/Executor/Executor.php
@@ -148,7 +148,7 @@ class Executor implements ExecutorInterface
         $executor = $this;
 
         array_walk_recursive($data, function(&$value, $key) use ($executor, $collection) {
-            if (preg_match('/^@([\w-_]*):([\w-_]*)$/', $value, $hit)) {
+            if (is_string($value) && preg_match('/^@([\w-_]*):([\w-_]*)$/', $value, $hit)) {
 
                 if (!$collection->has($hit[1]) || !$collection->get($hit[1])->get($hit[2])) {
                     throw new ReferenceNotFoundException($hit[1], $hit[2]);

--- a/tests/DavidBadura/Fixtures/Executor/ExecutorTest.php
+++ b/tests/DavidBadura/Fixtures/Executor/ExecutorTest.php
@@ -34,10 +34,13 @@ class ExecutorTest extends AbstractFixtureTest
 
     public function testSimpleFixture()
     {
+        $birthdate = new \DateTime();
+
         $userFixture = $this->createUserFixture(array(
             'david' => array(
                 'name' => 'David Badura',
-                'email' => 'd.badura@gmx.de'
+                'email' => 'd.badura@gmx.de',
+                'birthdate' => $birthdate
             )
         ));
 
@@ -51,6 +54,7 @@ class ExecutorTest extends AbstractFixtureTest
         $this->assertInstanceOf('DavidBadura\Fixtures\TestObjects\User', $object);
         $this->assertEquals('David Badura', $object->getName());
         $this->assertEquals('d.badura@gmx.de', $object->getEmail());
+        $this->assertEquals($birthdate, $object->getBirthDate());
     }
 
     public function testReference()

--- a/tests/DavidBadura/Fixtures/TestObjects/User.php
+++ b/tests/DavidBadura/Fixtures/TestObjects/User.php
@@ -38,6 +38,11 @@ class User
     private $groups = array();
 
     /**
+     * @var DateTime
+     */
+    private $birthdate;
+
+    /**
      *
      * @param string $name
      * @param string $email
@@ -105,6 +110,18 @@ class User
         $this->groups = $groups;
 
         return $this;
+    }
+
+    public function setBirthDate(\DateTime $birthdate)
+    {
+        $this->birthdate = $birthdate;
+
+        return $this;
+    }
+
+    public function getBirthDate()
+    {
+        return $this->birthdate;
     }
 
 }


### PR DESCRIPTION
| Question | Answer |
| --- | --- |
| Bug fix ? | yes |
| New feature ? | yes |
| BC breaks ? | no |
| Tests pass ? | yes |

I've add a little condition in Executor in order to be able to pass objects (like a DateTime) to the object setters.

This is needed when we use [Faker with your FixturesBundle](https://github.com/DavidBadura/FixturesBundle/blob/master/Resources/doc/faker.md)

Example :

``` yaml
users:
    properties:
        class: "MyCompany\Bundle\CoreBundle\Document\User"
    data:
        user{0..2}:
            firstname: <firstName()>
            lastname: <lastName()>
            birthdate: <dateTimeThisDecade()> # Without this patch, the command fails here
```
