### PR TITLE
Correct Executor regular expression.

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -99,7 +99,7 @@ class Executor implements ExecutorInterface
         $executor = $this;
 
         array_walk_recursive($data, function (&$value, $key) use ($executor, $collection) {
-            if (is_string($value) && preg_match('/^@([\w-_]*):([\w-_]*)$/', $value, $hit)) {
+            if (is_string($value) && preg_match('/^@([-_\w]*):([-_\w]*)$/', $value, $hit)) {
                 if (!$collection->has($hit[1]) || !$collection->get($hit[1])->get($hit[2])) {
                     throw new ReferenceNotFoundException($hit[1], $hit[2]);
                 }
@@ -146,7 +146,7 @@ class Executor implements ExecutorInterface
                 return;
             }
 
-            if (preg_match('/^@@([\w-_]*):([\w-_]*)$/', $value, $hit)) {
+            if (preg_match('/^@@([-_\w]*):([-_\w]*)$/', $value, $hit)) {
                 if (!$collection->has($hit[1]) || !$collection->get($hit[1])->get($hit[2])) {
                     throw new ReferenceNotFoundException($hit[1], $hit[2]);
                 }


### PR DESCRIPTION
The range `[\w-_]` causes the PHP warning of "Compilation failed: invalid range in character class" to be thrown because PCRE is interpreting it as a range between `\w` and `_`.  Simply re-ordering the range fixes the issue.