### PR TITLE
prevent type error on non-string fixture properties

### DIFF
--- a/src/FixtureManager/FixtureManager.php
+++ b/src/FixtureManager/FixtureManager.php
@@ -159,6 +159,9 @@ class FixtureManager implements FixtureManagerInterface
                 $data = $fixtureData->getData();
 
                 array_walk_recursive($data, function (&$item, &$key) use ($provider) {
+                    if (!is_string($item)) {
+                        return;
+                    }
                     $matches = [];
                     if (preg_match(FixtureManager::SERVICE_PLACEHOLDER_PATTERN, $item, $matches)) {
                         $service = $provider->get($matches[1]);


### PR DESCRIPTION
Since strict mode is enabled, using non-string values in fixture files will cause a type error here.