### PR TITLE
Allow nullable constructor arguments.

### DIFF
--- a/src/Converter/DefaultConverter.php
+++ b/src/Converter/DefaultConverter.php
@@ -39,11 +39,11 @@ class DefaultConverter implements ConverterInterface
             $optional = (substr($arg, 0, 1) == '?');
             $arg = ($optional) ? substr($arg, 1) : $arg;
 
-            if (!isset($data[$arg]) && !$optional) {
+            if (!\array_key_exists($arg, $data) && !$optional) {
                 throw new ConverterException(sprintf('Missing "%s" attribute', $arg));
             }
 
-            if (isset($data[$arg])) {
+            if (\array_key_exists($arg, $data)) {
                 $value = $data[$arg];
 
                 if (is_string($value)) {

--- a/tests/Converter/DefaultConverterTest.php
+++ b/tests/Converter/DefaultConverterTest.php
@@ -99,4 +99,26 @@ class DefaultConverterTest extends TestCase
         $this->assertEquals('test_name', $object->getName());
         $this->assertInstanceOf('DateTime', $object->getDate());
     }
+
+    public function testnullableCostructorArgument()
+    {
+        $fixture = new Fixture('test');
+        $fixture->setProperties(new ParameterBag([
+            'class' => User::class,
+            'constructor' => ['name', 'email'],
+        ]));
+
+        $data = new FixtureData('test', [
+            'name' => 'test_name',
+            'email' => null,
+        ]);
+
+        $data->setFixture($fixture);
+
+        $object = $this->converter->createObject($data);
+
+        $this->assertInstanceOf(User::class, $object);
+        $this->assertEquals('test_name', $object->getName());
+        $this->assertNull($object->getEmail());
+    }
 }

--- a/tests/TestObjects/User.php
+++ b/tests/TestObjects/User.php
@@ -14,7 +14,7 @@ class User
     private $groups = [];
     private $birthdate;
 
-    public function __construct(string $name, string $email)
+    public function __construct(string $name, ?string $email)
     {
         $this->name = $name;
         $this->email = $email;
@@ -30,12 +30,12 @@ class User
         $this->name = $name;
     }
 
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
-    public function setEmail(string $email): void
+    public function setEmail(?string $email): void
     {
         $this->email = $email;
     }


### PR DESCRIPTION
`isset()` does not behave as expected for null values in an array. This commit swaps the usages of `isset()` for `array_key_exists()` to allow for null values to be accepted as input for constructor args.

PS: This library has been fantastic for my needs, I really appreciate it!